### PR TITLE
not working when using it in a directive

### DIFF
--- a/src/angular-tooltip.js
+++ b/src/angular-tooltip.js
@@ -36,8 +36,8 @@
          */
         function attachTether() {
           new Tether(extend({
-            element: elem,
-            target: target
+            element: elem[0],
+            target: target[0]
           }, options.tether));
         };
 


### PR DESCRIPTION
elem and target are jQLite objects.
I had to fixe it this way to make it work when using my own directive.

```
app.directive('effTooltip', ['modTooltip', function($tooltip) {
  return {
    restrict: 'EA',
    scope: { show: '=effTooltip' },
    link: function(scope, elem) {
      debugger;
      var tooltip = $tooltip({
        target: elem,
        scope: scope,
        templateUrl: 'eff-tooltip.html'
      });

      scope.$watch('show', function(value) {
        if (value) {
          tooltip.open();
        } else {
          tooltip.close();
        }
      });

    }
  };
}]);
```

You should'nt accept the pull request, further testing are required. but it gives you a hint.

Also your naming convention was getting in conflict with others modules I use. I will maybe submit another pull request to fix the names
